### PR TITLE
Add Safari Support for MutationObserver

### DIFF
--- a/aframe/dropdown.html
+++ b/aframe/dropdown.html
@@ -43,14 +43,14 @@
 
 <script>
   var s = false;
-
-  var observer = new document.defaultView.parent.MutationObserver(function() {
+  function f() {
     if(!s){
       s=true
     } else {
       document.querySelector("#ddown").style.display="block";
     }
-  });
+  }
+  var observer = new MutationObserver(f) || new WebKitMutationObserver(f);
 
   observer.observe(document.defaultView.parent.document.querySelector(".a-loader-title"), {attributes:true});
 </script>


### PR DESCRIPTION
Dropdown on Safari (iPad particularly) was having some issues, hopefully this will fix